### PR TITLE
Add in a redirect after assignment...

### DIFF
--- a/includes/bookmark_class.inc
+++ b/includes/bookmark_class.inc
@@ -9,14 +9,24 @@ class NaldoraQCReviewList extends BookmarkDatabase {
   /**
    * Get the URL to this list.
    *
+   * @param bool $absolute
+   *   Whether or not to create an absolute URL, or just the site-local URL.
+   *
    * @return string
-   *   An absolute URL to this bookmark list, without langague prefixing.
+   *   An absolute URL to this bookmark list without langague prefixing if
+   *   $absolute is TRUE; otherwise, 'islandora-bookmark/listid/<the list id>'.
    */
-  protected function getListURL() {
-    return url("islandora-bookmark/listid/{$this->bookmarkId}", array(
-      'language' => NULL,
-      'absolute' => TRUE,
-    ));
+  public function getListURL($absolute = TRUE) {
+    $url = "islandora-bookmark/listid/{$this->bookmarkId}";
+    if ($absolute) {
+      return url($url, array(
+        'language' => NULL,
+        'absolute' => TRUE,
+      ));
+    }
+    else {
+      return $url;
+    }
   }
 
   /**

--- a/includes/solr_results.inc
+++ b/includes/solr_results.inc
@@ -166,7 +166,7 @@ class NaldoraQCSolrReviewResults extends IslandoraSolrResultsBookmark {
    * @param array $form_state
    *   The array of form state.
    */
-  protected function saveAll($form_state) {
+  protected function saveAll(&$form_state) {
     $pids = $this->getAll($form_state);
     $this->save($pids, $form_state);
   }
@@ -179,7 +179,7 @@ class NaldoraQCSolrReviewResults extends IslandoraSolrResultsBookmark {
    * @param array $form_state
    *   The array of form state.
    */
-  protected function saveSelected($form_state) {
+  protected function saveSelected(&$form_state) {
     $pids = $this->getSelected($form_state);
     $this->save($pids, $form_state);
   }
@@ -192,7 +192,7 @@ class NaldoraQCSolrReviewResults extends IslandoraSolrResultsBookmark {
    * @param array $form_state
    *   The array of form state.
    */
-  protected function save($pids_to_add, $form_state) {
+  protected function save($pids_to_add, &$form_state) {
     $reviewer_el = $form_state['complete form']['naldora_qc_review']['reviewer'];
     $reviewer = drupal_array_get_nested_value($form_state['values'], $reviewer_el['#parents']);
     $reviewer_object = user_load($reviewer);
@@ -226,6 +226,7 @@ class NaldoraQCSolrReviewResults extends IslandoraSolrResultsBookmark {
 
       // Associate the reviewer with the bookmark object.
       $bookmark_object->addUser($reviewer_object->uid);
+      $form_state['redirect'] = $bookmark_object->getListURL(FALSE);
     }
   }
 }


### PR DESCRIPTION
... Should get rid of showing objects which were assigned in the
QC review Solr display.
